### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/karthiknk81edu/0be10435-ddb8-48ec-a175-a3337d069433/b6aec8d2-8315-435f-9c03-ddb67fc9de43/_apis/work/boardbadge/d685ff3c-5af2-4919-a8e6-72e77b61da82)](https://dev.azure.com/karthiknk81edu/0be10435-ddb8-48ec-a175-a3337d069433/_boards/board/t/b6aec8d2-8315-435f-9c03-ddb67fc9de43/Microsoft.RequirementCategory)
 # algorithm


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#3](https://dev.azure.com/karthiknk81edu/0be10435-ddb8-48ec-a175-a3337d069433/_workitems/edit/3). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.